### PR TITLE
Show version number if GM_info supported

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -159,8 +159,12 @@
     Settings.addBool("filterChannel", "Filter by channel", false);
     // Options end
 
-    // Add version at the end
-    $("#settingContent").append('<div class="robin-chat--sidebar-widget robin-chat--report" style="text-align:center;"><a target="_blank" href="https://github.com/vartan/robin-grow">robin-grow</a></div>');
+    // Add version at the end (if available from script engine)
+    var versionString = "";
+    if (typeof GM_info !== "undefined") {
+        versionString = " - v" + GM_info.script.version;
+    }
+    $("#settingContent").append('<div class="robin-chat--sidebar-widget robin-chat--report" style="text-align:center;"><a target="_blank" href="https://github.com/vartan/robin-grow">robin-grow' + versionString + '</a></div>');
     // Settings end
 
     var timeStarted = new Date();


### PR DESCRIPTION
Previously we removed the version string from the settings box in case the user's script engine didn't support it. This instead checks for its availability, and if available, uses it to append the version number.

Also, in the unlikely chance the maintainer wants to increment the version number in two places (which `GM_info` is designed to help avoid), they are free to pre-fill the `versionNumber` variable with the current version number. Since doing so is less than ideal, I'd recommend only bothering to do so on major versions changes, e.g.: `1.8xx` -> `1.9xx`.
