### PR TITLE
Re-color user name list occasionally

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -481,10 +481,14 @@
         return flairColor[flairNum];
     }
 
-    // Color names in user list
-    $('#robinUserList').find('.robin--username').each(function(){
-        this.style.color = colorFromName(this.textContent);
-    });
+    // Color names in user list, unless they've already been colored
+    function colorUserListNames() {
+        $('#robinUserList').find('.robin--username:not([style])').each(function(){
+            this.style.color = colorFromName(this.textContent);
+        });
+    }
+    setInterval(colorUserListNames, 11000);
+    colorUserListNames();
 
     // Color current user's name in chat and darken post backgrounds
     var currentUserColor = colorFromName(currentUsersName);


### PR DESCRIPTION
When a user goes/comes back from idle they lose their color because their `style` attribute is lost when updated. My change sets the coloring on a timer (at an interval to rarely intersect with the `update()` one) and modifies the selector to only attempt to color usernames that are not already styled.
