### PR TITLE
Fix hiding time left display when 'ending soon'

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -231,7 +231,7 @@
                 $(".robin-chat--vote.robin--vote-class--increase:not('.robin--active')").click();
                 break;
         }
-        if (endTime === null) {
+        if (endTime === null && !isEndingSoon) {
             $(".timeleft").hide();
         }
         else {


### PR DESCRIPTION
Forgot to check is we're ending soon before hiding the time remaining display box.
