### PR TITLE
Make slash commands work in chat again (minor annoyance).

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -175,12 +175,11 @@
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
     $(".text-counter-input").keyup(function(e) {
-		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel + " /" == 0) {
-			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length))
+		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel+" /" == 0) {
+			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length));
 		}  
-        else if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0
-		    && $(".text-counter-input").val().charAt(0) != '/') {
-            $(".text-counter-input").val(settings.channel+" "+$(".text-counter-input").val())
+        else if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0 && $(".text-counter-input").val().charAt(0) != '/') {
+            $(".text-counter-input").val(settings.channel+" "+$(".text-counter-input").val());
         }
     });
 

--- a/robin.user.js
+++ b/robin.user.js
@@ -175,7 +175,7 @@
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
     $(".text-counter-input").keyup(function(e) {
-		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel+" /" == 0) {
+		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel+" /" == 0)) {
 			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length));
 		}  
         else if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0 && $(".text-counter-input").val().charAt(0) != '/') {

--- a/robin.user.js
+++ b/robin.user.js
@@ -175,7 +175,7 @@
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
     $(".text-counter-input").keyup(function(e) {
-		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel+" /" == 0)) {
+		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel+" /") == 0) {
 			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length));
 		}  
         else if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0 && $(".text-counter-input").val().charAt(0) != '/') {

--- a/robin.user.js
+++ b/robin.user.js
@@ -176,7 +176,7 @@
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
     $(".text-counter-input").keyup(function(e) {
 		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel+" /") == 0) {
-			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length));
+			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length + 1));
 		}  
         else if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0 && $(".text-counter-input").val().charAt(0) != '/') {
             $(".text-counter-input").val(settings.channel+" "+$(".text-counter-input").val());

--- a/robin.user.js
+++ b/robin.user.js
@@ -175,7 +175,11 @@
     var list = {};
     $(".text-counter-input").val(settings.filterChannel? settings.channel+" " :"")
     $(".text-counter-input").keyup(function(e) {
-        if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0) {
+		if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel + " /" == 0) {
+			$(".text-counter-input").val($(".text-counter-input").val().substring(settings.channel.length))
+		}  
+        else if(settings.filterChannel && $(".text-counter-input").val().indexOf(settings.channel) != 0
+		    && $(".text-counter-input").val().charAt(0) != '/') {
             $(".text-counter-input").val(settings.channel+" "+$(".text-counter-input").val())
         }
     });


### PR DESCRIPTION
Solves the issue where if you type a slash while in a channel, it gets sent to chat. Deletes the channel text when you lead off with a slash.
