### PR TITLE
Fix time left not showing

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -234,9 +234,9 @@
         }
         if (endTime === null && !isEndingSoon) {
             $(".timeleft").hide();
-        }
-        else {
-            $(".timeleft").text(isEndingSoon ? "ending soon" : formatNumber(howLongLeft(endTime)) + " minutes remaining");
+            endTime = getEndTime();
+        } else {
+            $(".timeleft").show().text(isEndingSoon ? "ending soon" : formatNumber(howLongLeft(endTime)) + " minutes remaining");
         }
 
         var users = 0;


### PR DESCRIPTION
In some cases (maybe RES + Firefox, that's what I use) the time left is not showing up.
It happens because when the script is run the system chat message isn't there yet and it is never checked again afterwards. With this edit the time left is checked again on update when it hasn't been found before.
