### PR TITLE
Fix userlist overlap in Safari

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -87,7 +87,7 @@
 
             $('.robin-chat--buttons').prepend("<div class='robin-chat--vote robin--vote-class--novote'><span class='robin--icon'></span><div class='robin-chat--vote-label'></div></div>");
             $robinVoteWidget.find('.robin-chat--vote').css('padding', '5px');
-            $('.robin-chat--user-list-widget').css('margin-top', '122px');
+            if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) $('.robin-chat--user-list-widget').css('margin-top', '122px');
             $('.robin--vote-class--novote').css('pointer-events', 'none');
         },
 


### PR DESCRIPTION
Follows on from #143 and #144 — Fix now targets only Safari.

Tested in Safari 9.1 (OS X 10.11.4) and Chrome 49.0.2623.
